### PR TITLE
Add hdf and mkl libraries to intel.mk

### DIFF
--- a/exec/templates/intel.mk
+++ b/exec/templates/intel.mk
@@ -5,10 +5,10 @@
 
 ############
 # Command Macros
-FC = ifort
-CC = icc
-CXX = icpc
-LD = ifort
+FC = mpiifort
+CC = mpiicc
+CXX = mpiicpc
+LD = mpiifort
 
 #######################
 # Build target macros
@@ -172,6 +172,18 @@ ifndef MPI_LIBS
 LIBS += $(shell pkg-config --libs mpich2-f90)
 else
 LIBS += $(MPI_LIBS)
+endif
+# HDF library flags
+ifndef HDF_LIBS
+LIBS += -lhdf5 -lhdf5_fortran -lhdf5_hl -lhdf5hl_fortran
+else
+LIBS += $(HDF_LIBS)
+endif
+# MKL library flags
+ifndef MKL_LIBS
+LIBS += -lmkl_blas95_lp64 -lmkl_lapack95_lp64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential
+else
+LIBS += $(MKL_LIBS)
 endif
 
 # Get compile flags based on target macros.

--- a/run/AM4_run_script.sh
+++ b/run/AM4_run_script.sh
@@ -14,7 +14,7 @@ mpiexec_nopt=-n
 # Option used to specify number of OpenMP threads to run
 mpiexec_topt=-d
 
-# Where to perform the run 
+# Where to perform the run
 # If using AM4.tar, this should be AM4_run
 workDir=/path/to/run/dir
 
@@ -29,9 +29,9 @@ executable=/path/to/executable/fms_cm4p12_warsaw.x
 
 
 ## Run parameters
-#total_npes is the number of cores to run on, omp_threads is the number of 
+#total_npes is the number of cores to run on, omp_threads is the number of
 # openMP threads
-total_npes=216
+total_npes=432
 omp_threads=1
 
 # End of configuration section
@@ -113,7 +113,7 @@ then
 fi
 
 ## Use this section if you are untar'ing the input data ##
-## Not required if sing AM4.tar out of the box          ## 
+## Not required if sing AM4.tar out of the box          ##
 ## Extract the input data
 #tar xf ${inputDataTar}
 #if [ $? -ne 0 ]


### PR DESCRIPTION
The `intel.mk` file didn't have the hdf5 and mkl libraries listed.  These are now added.

Also corrected a few inconsistencies in the run script example.