### PR TITLE
intel.mk template update for mkl libraries

### DIFF
--- a/exec/templates/intel.mk
+++ b/exec/templates/intel.mk
@@ -9,7 +9,6 @@ FC = mpiifort
 CC = mpiicc
 CXX = mpiicpc
 LD = mpiifort
-
 #######################
 # Build target macros
 #
@@ -180,10 +179,13 @@ else
 LIBS += $(HDF_LIBS)
 endif
 # MKL library flags
-ifndef MKL_LIBS
-LIBS += -lmkl_blas95_lp64 -lmkl_lapack95_lp64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential
+ifeq ($(MKL_LIBS),none)
 else
-LIBS += $(MKL_LIBS)
+ ifndef MKL_LIBS
+ LIBS += -lmkl_blas95_lp64 -lmkl_lapack95_lp64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential
+ else
+ LIBS += $(MKL_LIBS)
+ endif
 endif
 
 # Get compile flags based on target macros.


### PR DESCRIPTION
On some systems, including the mkl libraries causes a crash on the linking step.  This branch changes the logic for MKL_LIBS in intel.mk.  Now a user can specify MKL_LIBS=none in their `make` command to exclude the mkl libraries on the link step of the compile.  I wrapped the old logic in an if like this
```
ifeq ($(MKL_LIBS),none)
else
OLD MKL_LIBS LOGIC
endif
```