### PR TITLE
Update make templates to guess HDF5 directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.mod
 *.DO_NOT_MODIFY.f90
 *.x
+*.a

--- a/exec/templates/intel.mk
+++ b/exec/templates/intel.mk
@@ -38,12 +38,17 @@ endif
 # variables.  If these options are not defined, the makefile will
 # attempt to get the correct options from the `nf-config` command.
 
+# HDF_FLAGS
+# HDF_LDFLAGS
+# HDF_LIBS
+# If defined, use the HDF5 compile and link options defined in these
+# variables.  If these options are note defined, then makefile will 
+# attempt ot get the correct options from the `h5fc -show` command.
+
 # MPI_FLAGS
 # MPI_LIBS
 # If defined, use the MPI compile and link options defined in these
-# variables.  If these options are not defined, the makefile will
-# attempt to get the correct options from the `pkg-config` for mpich2
-# MPI library.
+# variables.  
 
 # VERBOSE
 # If non-blank, add additional verbosity compiler options
@@ -95,9 +100,7 @@ else
 FPPFLAGS += $(NETCDF_FLAGS)
 endif
 # Fortran Compiler flags for the MPICH MPI library
-ifndef MPI_FLAGS
-FPPFLAGS += $(shell pkg-config --cflags-only-I mpich2-c)
-else
+ifdef MPI_FLAGS
 FPPFLAGS += $(MPI_FLAGS)
 endif
 
@@ -124,9 +127,7 @@ else
 CPPFLAGS += $(NETCDF_FLAGS)
 endif
 # C Compiler flags for the MPICH MPI library
-ifndef MPI_FLAGS
-CPPFLAGS += $(shell pkg-config --cflags-only-I mpich2-c)
-else
+ifdef MPI_FLAGS
 CPPFLAGS += $(MPI_FLAGS)
 endif
 
@@ -158,6 +159,19 @@ LDFLAGS_OPENMP := -qopenmp
 LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
 LDFLAGS_COVERAGE = -prof-gen=srcpos
 
+# HDF flags
+ifndef HDF5_FFLAGS
+FFLAGS += $(shell myflags=''; for c in $$(h5fc -show); do if [ x"$$(echo $$c | cut -c1-2)" = "x-I" ]; then myflags="$${myflags} $$c"; fi; done; echo $${myflags})
+else
+FFLAGS += $(HDF5_FFLAGS)
+endif
+
+ifndef HDF5_LDFLAGS
+LDFLAGS += $(shell myflags=''; for c in $$(h5fc -show); do if [ x"$$(echo $$c | cut -c1-2)" = "x-L" ]; then myflags="$${myflags} $$c"; fi; done; echo $${myflags})
+else
+LDFLAGS += $(HDF5_LDFLAGS)
+endif
+
 # Start with a blank LIBS
 LIBS =
 # NetCDF library flags
@@ -167,9 +181,7 @@ else
 LIBS += $(NETCDF_LIBS)
 endif
 # MPICH MPI library flags
-ifndef MPI_LIBS
-LIBS += $(shell pkg-config --libs mpich2-f90)
-else
+ifdef MPI_LIBS
 LIBS += $(MPI_LIBS)
 endif
 # HDF library flags


### PR DESCRIPTION
Added new configuration variables HDF5_LDFLAGS and HDF5_FLAGS to allow user to set location of HDF5 directories.  Also added bits to have make guess location using the `h5fc -show` command.

Fixes #21 