### PR TITLE
release/MG2_xanadu_2020.02.01 update

### DIFF
--- a/exec/atmos_dyn/Makefile
+++ b/exec/atmos_dyn/Makefile
@@ -2,7 +2,7 @@
 
 CPPDEFS = -DINTERNAL_FILE_NML -g -DCLIMATE_NUDGE -DSPMD 
 
-OTHERFLAGS = -I$(BUILDROOT)atmos_phys -I$(BUILDROOT)fms -I$(SRCROOT)shared/include
+OTHERFLAGS = -I$(BUILDROOT)atmos_cubed_sphere -I$(BUILDROOT)atmos_phys -I$(BUILDROOT)fms -I$(SRCROOT)shared/include
 
 include $(MK_TEMPLATE)
 


### PR DESCRIPTION
Adds `-I$(BUILDROOT)atmos_cubed_sphere` to `OTHERFLAGS` in atmos_dyn/Makefile